### PR TITLE
Make use of ALBs optional in control plane

### DIFF
--- a/modules/control_plane/outputs.tf
+++ b/modules/control_plane/outputs.tf
@@ -1,5 +1,5 @@
 output "domain" {
-  value = "${var.use_route53 ? aws_route53_record.control_plane.0.name : ""}"
+  value = "${join("",aws_route53_record.control_plane.*.name)}"
 }
 
 output "subnet_ids" {
@@ -19,11 +19,15 @@ output "subnet_availability_zones" {
 }
 
 output "credhub_lb_target_group" {
-  value = "${aws_lb_target_group.credhub.name}"
+  # https://github.com/hashicorp/terraform/issues/12475
+  # outputs do not allow for the ternary operator. Because only one of these target groups will ever be created, this is a safe alternative
+  value = "${coalesce(join("", aws_lb_target_group.credhub.*.name), join("",aws_lb_target_group.credhub_tcp.*.name))}"
 }
 
 output "uaa_lb_target_group" {
-  value = "${aws_lb_target_group.uaa.name}"
+  # https://github.com/hashicorp/terraform/issues/12475
+  # outputs do not allow for the ternary operator. Because only one of these target groups will ever be created, this is a safe alternative
+  value = "${coalesce(join("", aws_lb_target_group.uaa.*.name), join("",aws_lb_target_group.uaa_tcp.*.name))}"
 }
 
 output "atc_lb_target_group" {

--- a/modules/control_plane/variables.tf
+++ b/modules/control_plane/variables.tf
@@ -24,6 +24,8 @@ variable "zone_id" {
 
 variable "use_route53" {}
 
+variable "use_alb" {}
+
 variable "dns_suffix" {
   type = "string"
 }

--- a/terraforming-control-plane/main.tf
+++ b/terraforming-control-plane/main.tf
@@ -85,6 +85,7 @@ module "control_plane" {
   dns_suffix              = "${var.dns_suffix}"
   zone_id                 = "${module.infra.zone_id}"
   use_route53             = "${var.use_route53}"
+  use_alb                 = "${var.use_alb}"
 
   lb_cert_pem        = "${var.tls_wildcard_certificate}"
   lb_issuer          = "${var.tls_ca_certificate}"

--- a/terraforming-control-plane/variables.tf
+++ b/terraforming-control-plane/variables.tf
@@ -23,6 +23,11 @@ variable "use_route53" {
   description = "Indicate whether or not to enable route53"
 }
 
+variable "use_alb" {
+  default     = true
+  description = "if false, use NLBs instead of ALBs for Credhub and UAA"
+}
+
 variable "top_level_zone_id" {
   default     = ""
   description = "Root hosted zone that we are going to wire NS records to for Let's encrypt"


### PR DESCRIPTION
US Gov Cloud does not allow for ALBs. This PR allows for that, by
setting a new flag `use_alb` that, when set to false, will create
2 new NLBs for credhub and uaa, rather than a single ALB, with a
similar user experience. The default has been set to true so that
existing tfvars files will continue to work as it has before.